### PR TITLE
Fix CalcStringWidth return corrupt value

### DIFF
--- a/OrangeUIControl/Source/Base/uSkinBufferBitmap.pas
+++ b/OrangeUIControl/Source/Base/uSkinBufferBitmap.pas
@@ -465,7 +465,7 @@ begin
           if GetGlobalAutoSizeBufferBitmap.DrawCanvas.CalcTextDrawSize(
                                                               ADrawTextParam,
                                                               AStr,
-                                                              RectF(ADrawRect.Left,ADrawRect.Top,MaxInt,ADrawRect.Bottom),
+                                                              RectF(ADrawRect.Left,ADrawRect.Top,$FFFF,ADrawRect.Bottom),
                                                               AWidth,
                                                               AHeight,cdstBoth) then
           begin


### PR DESCRIPTION
Fix CalcStringWidth return corrupt value on some words like "Download"
修复某些文字获取的宽度是128定值的问题。
第一个pull request，庆祝老湿走开源路线共同进步